### PR TITLE
fix: current ranges should include today

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can use `moment().current(measure)`:
 var thisMonth = moment().current('month');
 
 // thisMonth.start = start of the month
-// thisMonth.end = yesterday
+// thisMonth.end = today
 // thisMonth.length = the number of days since the start of this month
 ```
 

--- a/src/relative-range.js
+++ b/src/relative-range.js
@@ -65,7 +65,11 @@ const rangeSchema = {
   },
   margin: {
     type: Number,
-    default: 1,
+    calculate(value?: ?number): number | void | null {
+      const defaultValue = this.type === RANGE_TYPES.current ? 0 : 1;
+
+      return value !== undefined ? value : defaultValue;
+    },
   },
   start: {
     type: Date,

--- a/tests/relative-range.spec.js
+++ b/tests/relative-range.spec.js
@@ -74,6 +74,7 @@ describe('RelativeRange', function () {
       expect(clone.units).to.equal(5);
       expect(clone.measure).to.equal('day');
       expect(clone.type).to.equal('previous');
+      expect(clone.margin).to.equal(1);
     });
   });
 
@@ -87,6 +88,7 @@ describe('RelativeRange', function () {
       expect(clone.units).to.equal(1);
       expect(clone.measure).to.equal('month');
       expect(clone.type).to.equal('current');
+      expect(clone.margin).to.equal(0);
     });
   });
 
@@ -99,6 +101,7 @@ describe('RelativeRange', function () {
       expect(clone.units).to.equal(3);
       expect(clone.measure).to.equal('month');
       expect(clone.type).to.equal('next');
+      expect(clone.margin).to.equal(1);
     });
   });
 
@@ -282,35 +285,35 @@ describe('RelativeRange', function () {
       this.range.measure = 'week';
 
       expect(this.range.start.format(DAY_FORMAT), 'start date').to.equal('3000-02-09');
-      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-11');
+      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-12');
     });
 
     it('isoWeek', function () {
       this.range.measure = 'isoWeeks';
 
       expect(this.range.start.format(DAY_FORMAT), 'start date').to.equal('3000-02-10');
-      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-11');
+      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-12');
     });
 
     it('month', function () {
       this.range.measure = 'month';
 
       expect(this.range.start.format(DAY_FORMAT), 'start date').to.equal('3000-02-01');
-      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-11');
+      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-12');
     });
 
     it('year', function () {
       this.range.measure = 'year';
 
       expect(this.range.start.format(DAY_FORMAT), 'start date').to.equal('3000-01-01');
-      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-11');
+      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-12');
     });
 
     it('quarter', function () {
       this.range.measure = 'quarter';
 
       expect(this.range.start.format(DAY_FORMAT), 'start date').to.equal('3000-01-01');
-      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-11');
+      expect(this.range.end.format(DAY_FORMAT), 'end date').to.equal('3000-02-12');
     });
   });
 


### PR DESCRIPTION
Asking for the current week should include today. It used to be limited to yesterday, which is only logical for `previous` ranges.